### PR TITLE
Restore home activity title

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/HomeActivity.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/HomeActivity.java
@@ -48,7 +48,6 @@ public class HomeActivity extends AppCompatActivity {
         setContentView(R.layout.activity_home);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-        toolbar.setTitle("");
         setSupportActionBar(toolbar);
 
         Analytics.trackScreenView(HomeActivity.class.getSimpleName());


### PR DESCRIPTION
Not sure if this was intentionally removed or not. For the time being, I recommend that we restore the title. Mainly because the action badge currently reads "saves you" and "saved you", having the title in the toolbar helps add some additional context there.
