### PR TITLE
Fix index out of bounds crash

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/util/AppPoller.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/util/AppPoller.java
@@ -118,7 +118,7 @@ public class AppPoller {
                     //Log.d(TAG, "Checking current tasks...");
                     List<ActivityManager.RunningTaskInfo> runningTasks = am.getRunningTasks(1);
                     if (runningTasks.isEmpty()) {
-                        Log.d(TAG, "No running tasks!");
+                        CrashTracking.log(TAG + ": No running tasks!");
                         break;
                     }
 


### PR DESCRIPTION
This is from the #2 top crasher:
https://fabric.io/brave6/android/apps/com.linkbubble.playstore/issues/55c91c86e0d514e5d6e435f0

I don't fully understand why it can be empty but I did trace the code to
make sure if hitting the early break doesn't cause harm.
