### PR TITLE
Adjust home activity button in portrait mode

### DIFF
--- a/Application/LinkBubble/src/main/res/layout/activity_home.xml
+++ b/Application/LinkBubble/src/main/res/layout/activity_home.xml
@@ -48,7 +48,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal|bottom"
             android:id="@+id/action_button_container"
-            android:layout_marginBottom="16dp">
+            android:layout_marginBottom="@dimen/home_activity_bottom_margin">
 
             <View
                 android:layout_width="214dp"

--- a/Application/LinkBubble/src/main/res/values-land/dimens.xml
+++ b/Application/LinkBubble/src/main/res/values-land/dimens.xml
@@ -4,4 +4,5 @@
     <dimen name="stat_bubble_size">110dp</dimen>
     <dimen name="stat_bubble_text_size">24sp</dimen>
     <dimen name="home_logo_margin_right">24dp</dimen>
+    <dimen name="home_activity_bottom_margin">16dp</dimen>
 </resources>

--- a/Application/LinkBubble/src/main/res/values/dimens.xml
+++ b/Application/LinkBubble/src/main/res/values/dimens.xml
@@ -30,6 +30,7 @@
     <dimen name="settings_icon_size">32dp</dimen>
 
     <dimen name="snackbar_height">64dp</dimen>
+    <dimen name="home_activity_bottom_margin">64dp</dimen>
 
     <dimen name="back_indicator_size">16dp</dimen>
     <dimen name="badge_size">24dp</dimen>


### PR DESCRIPTION
See screenshots in the pull request after this lands.

This adds a bigger margin for the button in the home activity in
portrait mode so the snackbar doesn't overlap. I tried finding a middle ground with a single
layout xml but didn't have luck.  It's typical to fork layout xml fies
for diff orientations.
