### PR TITLE
Only reload a single bubble for now. Fixes #523.

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/webrender/WebViewRenderer.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/webrender/WebViewRenderer.java
@@ -73,6 +73,8 @@ class WebViewRenderer extends WebRenderer {
     private ArticleContent.BuildContentTask mBuildArticleContentTask;
     private ArticleContent mArticleContent;
 
+    private static NetworkReceiver mLastNetworkReceiver = null;
+
     public WebViewRenderer(Context context, Controller controller, View webRendererPlaceholder, String tag) {
         super(context, controller, webRendererPlaceholder);
 
@@ -441,9 +443,17 @@ class WebViewRenderer extends WebRenderer {
             // Reload webviews once we have a connection.
             if (NetworkConnectivity.isConnected(mContext) == false) {
                 Log.d(TAG, "Not connected, will retry on connection.");
+
+                // We only reload a single webview at a time, so if there is a previous receiver, we unregister it.
+                if (mLastNetworkReceiver != null) {
+                    mContext.unregisterReceiver(mLastNetworkReceiver);
+                    mLastNetworkReceiver = null;
+                }
+
                 IntentFilter filter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
                 NetworkReceiver receiver = new NetworkReceiver(WebViewRenderer.this);
                 mContext.registerReceiver(receiver, filter);
+                mLastNetworkReceiver = receiver;
             }
             mController.onReceivedError();
         }

--- a/Application/LinkBubble/src/main/res/xml/changelog.xml
+++ b/Application/LinkBubble/src/main/res/xml/changelog.xml
@@ -2,7 +2,7 @@
 <changelog>
 
     <release version="1.5.3">
-        <change></change>
+        <change>IMPROVEMENT: Offline bubble reloading will now only reload the most recent bubble. This is to reduce memory usage while also improving loading speed and stability.</change>
     </release>
 
     <release version="1.5.2">


### PR DESCRIPTION
This unregisters previous network receivers as we attempt to add more, only reloading a single bubble at a time. I think this is a more conservative approach, and we can go with this while we collect additional user feedback on the feature.

@bbondy - Please review when you get a chance, this is the best fix I could think of for now.
