### PR TITLE
Remove custom history stack handling.

### DIFF
--- a/Application/LinkBubble/src/main/assets/test.html
+++ b/Application/LinkBubble/src/main/assets/test.html
@@ -162,6 +162,11 @@ google.maps.event.addDomListener(window, 'load', initialize);
 <button onclick="onNewTab()">Open URL in new tab</button><br><br>
 Click <a href="#" onclick="javascript:window.open('','_self').close();">HERE</a> to close the current tab<br><br>
 
+<p>target="_blank" link. Verify that back button works in the newly opened page. It should be able to navigate back after clicking a link, and close the bubble.</p>
+<p><a target="_blank" rel="external" href="#">Tap to open example page in a new bubble.</a></p>
+
+<p>Verify that back button works after 301 test page.</p>
+<p><a href="https://jigsaw.w3.org/HTTP/300/">301 redirect test page</a></p>
 
 <form action="">
 <select name="cars">

--- a/Application/LinkBubble/src/main/java/com/linkbubble/articlerender/ArticleRenderer.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/articlerender/ArticleRenderer.java
@@ -23,7 +23,7 @@ public class ArticleRenderer {
     public interface Controller {
         public void onUrlLongClick(WebView webView, String url, int type);
         public void onDownloadStart(String urlAsString);
-        public boolean onBackPressed();
+        public boolean onBackPressed(WebView webView);
         public void onShowBrowserPrompt();
         public void onFirstPageLoadStarted();
     }
@@ -149,7 +149,7 @@ public class ArticleRenderer {
             if (event.getAction() == KeyEvent.ACTION_DOWN && mIsDestroyed == false) {
                 switch (keyCode) {
                     case KeyEvent.KEYCODE_BACK: {
-                        return mController.onBackPressed();
+                        return mController.onBackPressed(mWebView);
                     }
                 }
             }

--- a/Application/LinkBubble/src/main/java/com/linkbubble/webrender/WebRenderer.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/webrender/WebRenderer.java
@@ -23,12 +23,12 @@ public abstract class WebRenderer {
         public void onLoadUrl(String urlAsString);      // may or may not be called
         public void onReceivedError();
         public void onPageStarted(String urlAsString, Bitmap favIcon);
-        public void onPageFinished(String urlAsString);
+        public void onPageFinished(WebView webView, String urlAsString);
         public void onDownloadStart(String urlAsString);
         public void onReceivedTitle(String url, String title);
         public void onReceivedIcon(Bitmap bitmap);
         public void onProgressChanged(int progress, String urlAsString);
-        public boolean onBackPressed();
+        public boolean onBackPressed(WebView webView);
         public void onUrlLongClick(WebView webView, String url, int type);
         public void onShowBrowserPrompt();
         public void onCloseWindow();

--- a/Application/LinkBubble/src/main/res/xml/changelog.xml
+++ b/Application/LinkBubble/src/main/res/xml/changelog.xml
@@ -3,6 +3,7 @@
 
     <release version="1.6.1">
         <change>NEW: Long pressing on image links now gives you the option of opening the image or the link address in a new bubble.</change>
+        <change>FIX: Back button handling has been refactored to fix a few cases where pressing the back button would close the bubble.</change>
         <change>FIX: Addressed a few small crashes for improved stability.</change>
     </release>
 


### PR DESCRIPTION
This fixes #554, but I'm afraid that it will likely bring back lots of other bugs. Need to investigate and make sure that everything is still working with 3xx redirects, and native app opening.

75c8c2770f1b2068f650d7434f8b1ed1443d58ff reverted this, so we should be sure that this is fixing more than it's breaking. That changeset mentions the following issues: #324, #313, #303
