### PR TITLE
Attempt to prevent 301 redirects from loading.

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
@@ -117,6 +117,7 @@ public class ContentView extends FrameLayout {
     private String mInitialUrlAsString;
     private String mLoadingString;
     private Context mContext;
+    private String mCurrentUrl;
 
     // We only want to handle this once per link. This prevents 3+ dialogs appearing for some links, which is a bad experience. #224
     private boolean mHandledAppPickerForCurrentUrl = false;
@@ -405,6 +406,11 @@ public class ContentView extends FrameLayout {
 
         @Override
         public boolean shouldOverrideUrlLoading(WebView webView, String urlAsString) {
+            if(mCurrentUrl != null && urlAsString != null && urlAsString.equals(mCurrentUrl)) {
+                webView.goBack();
+                return true;
+            }
+
             if (mLifeState != LifeState.Alive) {
                 return true;
             }
@@ -438,6 +444,7 @@ public class ContentView extends FrameLayout {
             removeCallbacks(mDelayedAutoContentDisplayLinkLoadedRunnable);
 
             updateAndLoadUrl(urlAsString);
+            mCurrentUrl = urlAsString;
             return true;
         }
 


### PR DESCRIPTION
This still needs more work before review.

This allows users to navigate backwards through 301 redirects by preventhing them from loading. Currently 301s load when navigating back, which makes it difficult to close bubbles from twitter. Unfortunately this has the side-effect of showing a white page, when instead we should probably keep navigating back. We probably don't want to land this either without a notice, and potentially forward button as the user can still resture the bubble in a blank state.

This is an attempt at fixing #562.
