### PR TITLE
Automatically load LinkBubble if it's found as a valid target

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/MainController.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/MainController.java
@@ -737,7 +737,15 @@ public class MainController implements Choreographer.FrameCallback {
                     return null;
                 }
             } else {
-                showAppPicker = true;
+                // If LinkBubble is a valid resolve target, do not show other options to open the content.
+                for (ResolveInfo info : resolveInfos) {
+                    if (info.activityInfo.packageName.startsWith("com.linkbubble.playstore")) {
+                        showAppPicker = false;
+                        break;
+                    } else {
+                        showAppPicker = true;
+                    }
+                }
             }
         }
 

--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
@@ -534,8 +534,16 @@ public class ContentView extends FrameLayout {
                         }
                     }
                 } else {
-                    boolean isOnlyLinkBubble = mAppsForUrl.size() == 1 ? Util.isLinkBubbleResolveInfo(mAppsForUrl.get(0).mResolveInfo) : false;
-                    if (isOnlyLinkBubble == false && MainApplication.sShowingAppPickerDialog == false &&
+                    boolean isLinkBubblePresent = false;
+                    //boolean isLinkBubblePresent = mAppsForUrl.size() == 1 ? Util.isLinkBubbleResolveInfo(mAppsForUrl.get(0).mResolveInfo) : false;
+                    for (AppForUrl info : mAppsForUrl) {
+                        if (info.mResolveInfo.activityInfo.packageName.startsWith("com.linkbubble.playstore")) {
+                            isLinkBubblePresent = true;
+                            break;
+                        }
+                    }
+
+                    if (isLinkBubblePresent == false && MainApplication.sShowingAppPickerDialog == false &&
                             mHandledAppPickerForCurrentUrl == false && mAppPickersUrls.contains(urlAsString) == false) {
                         final ArrayList<ResolveInfo> resolveInfos = new ArrayList<ResolveInfo>();
                         for (AppForUrl appForUrl : mAppsForUrl) {


### PR DESCRIPTION
This might be a quick fix for #579, though it doesn't feel like it's the proper one. The problem is that Settings:getAppsThatHandleUrl is now returning additional apps, and I haven't tracked down exactly why that is the case. I would like to stop the bleeding asap, and I think this might be one way of doing it. I'm not sure if the default apps are functioning properly with this approach.

Fixes #579.
