### PR TITLE
Don't use script insertion for selects with stable webviews. Fixes #593

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/MainController.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/MainController.java
@@ -5,6 +5,7 @@ import android.app.KeyguardManager;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.graphics.PixelFormat;
@@ -653,6 +654,29 @@ public class MainController implements Choreographer.FrameCallback {
             return;
         }
         switchToBubbleView();
+    }
+
+    // Before this version select elements would crash WebView in a background service
+    public static final long STABLE_SELECT_WEBVIEW_VERSIONCODE = 249007650;
+    private long mVersionNumber = 0;
+
+    public long getWebviewVersion(Context context) {
+        if (mVersionNumber != 0) {
+            return mVersionNumber;
+        }
+
+        PackageManager pm = context.getPackageManager();
+        try {
+            PackageInfo pi = pm.getPackageInfo("com.google.android.webview", 0);
+            mVersionNumber =  pi.versionCode;
+        } catch (PackageManager.NameNotFoundException e) {
+            mVersionNumber = -1;
+        }
+        return mVersionNumber;
+    }
+
+    public boolean hasStableWebViewForSelects(Context context) {
+        return getWebviewVersion(context) >= STABLE_SELECT_WEBVIEW_VERSIONCODE;
     }
 
     public void onOrientationChanged() {

--- a/Application/LinkBubble/src/main/java/com/linkbubble/util/PageInspector.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/util/PageInspector.java
@@ -13,6 +13,7 @@ import android.webkit.WebView;
 
 import com.linkbubble.Config;
 import com.linkbubble.Constant;
+import com.linkbubble.MainController;
 import com.linkbubble.Settings;
 import com.linkbubble.articlerender.ArticleContent;
 import com.squareup.picasso.Picasso;
@@ -79,7 +80,9 @@ public class PageInspector {
         if (mScriptCache == null) {
             mScriptCache = "javascript:(function() {\n";
 
-            mScriptCache += getFileContents("SelectElements");
+            if (!MainController.get().hasStableWebViewForSelects(mContext)) {
+                mScriptCache += getFileContents("SelectElements");
+            }
 
             mScriptCache += getFileContents("TouchIcon");
 

--- a/Application/LinkBubble/src/main/res/xml/changelog.xml
+++ b/Application/LinkBubble/src/main/res/xml/changelog.xml
@@ -2,7 +2,7 @@
 <changelog>
 
     <release version="1.6.7">
-        <change></change>
+        <change>IMPROVEMENT: Uses built in drop downs for devices with stable WebViews.</change>
     </release>
 
     <release version="1.6.6">


### PR DESCRIPTION
This does a 1 time check for the webview version number and then caches the value for later checks.
