### PR TITLE
Optimized battery usage for expanded and at rest bubbles. Fixes #575

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/BubbleFlowView.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/BubbleFlowView.java
@@ -132,12 +132,12 @@ public class BubbleFlowView extends HorizontalScrollView {
                         mBubbleFlowListener.onCenterItemLongClicked(BubbleFlowView.this, mTouchView);
                     }
                 }
-            }
 
-            // Check mContent rather than mViews, because it's possible for mViews to be empty yet mContent have a child
-            // (e.g, in the instance the final Bubble is animating off screen).
-            if (mContent.getChildCount() > 0) {
-                result = true;
+                // Check mContent rather than mViews, because it's possible for mViews to be empty yet mContent have a child
+                // (e.g, in the instance the final Bubble is animating off screen).
+                if (mContent.getChildCount() > 0) {
+                    result = true;
+                }
             }
             return result;
         }

--- a/Application/LinkBubble/src/main/res/xml/changelog.xml
+++ b/Application/LinkBubble/src/main/res/xml/changelog.xml
@@ -2,6 +2,7 @@
 <changelog>
 
     <release version="1.6.7">
+        <change>IMPROVEMENT: Optimized battery usage for expanded and at rest bubbles.</change>
         <change>IMPROVEMENT: Uses built in drop downs for devices with stable WebViews.</change>
     </release>
 


### PR DESCRIPTION
Updates would constantly be scheduled even for at rest and expanded
bubbles because mTouchView can be non null sometimes.   The cehck for
scheduling an update is now also be gated on mStillTouchFrameCount > -1.

The problem was introduced in January 2014

Was introduced for a fix to this issue:
https://github.com/brave/link-bubble/issues/189

Changeset which introduced it:
https://github.com/brave/link-bubble/commit/1a831eb45e487162c0748e59864f49a01b612d7a
