### PR TITLE
fix and consolidate git repository for npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,8 @@
     "postinstall": "sh ./scripts/copyJNIFiles.js",
     "lint": "semistandard scripts/* Application/LinkBubble/src/main/assets/pagescripts/*"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/brave/link-bubble.git"
-  },
-  "author": "The Link Bubble Team <support@linkbubble.com>",
+  "repository": "brave/browser-android",
+  "author": "Brave Software <support@brave.com>",
   "licenses": [
     {
       "type": "MPL",
@@ -20,7 +17,7 @@
     }
   ],
   "bugs": {
-    "url": "https://github.com/brave/link-bubble/issues"
+    "url": "https://github.com/brave/browser-android/issues"
   },
   "devDependencies": {
     "babel": "^5.8.21",


### PR DESCRIPTION
We can use the same shortcut syntax for repository that we use for npm install. This makes it consistent with browser-laptop's [configuration](https://github.com/brave/browser-laptop/blob/master/package.json#L29). (cf https://docs.npmjs.com/files/package.json#repository)
