### PR TITLE
support substring match for Domain redirects. e.g: .doorkeeper.com

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/Settings.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/Settings.java
@@ -868,6 +868,11 @@ public class Settings {
 
     public boolean redirectUrlToBrowser(URL url) {
         String host = url.getHost();
+        for(String redirectHost : mFallbackRedirectHosts) {
+            if (host.endsWith(redirectHost)) {
+                return true;
+            }
+        }
         String hostAlt = host.contains("www.") ? host.replace("www.", "") : "www." + host;
         return mFallbackRedirectHosts.contains(host) || mFallbackRedirectHosts.contains(hostAlt);
 


### PR DESCRIPTION
I requested below function to brave on April/15/2016.
And issue is https://github.com/brave/browser-android/issues/749.

Finally I created patch and currently I use self-compiled brave on my Nexus 5(Android6.0) without issue.
I hope to accept this changes.

Yours.
------
I bought Link Bubble for Android and currently use Brave for Android.
This application is very useful and I like it.

But some reasons, I added "Domain redirects".
Unfortunately currently "Domain redirects" is not support regular expression or sub string match.

For example, there are many URLs for same domain("doorkeeper.jp")
https://jazug.doorkeeper.jp/
https://nishinipporirb.doorkeeper.jp/
....

If I want to "Domain redirects" above urls, I need to set all hostnames.
So do you have any support plan about regular expression or sub string match?