### PR TITLE
Autocomplete

### DIFF
--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
@@ -134,7 +134,7 @@ public class ContentView extends FrameLayout {
     private ImageButton mbtUrlClear;
     private FrameLayout mContentEditUrl;
     private String previousMetUrl;
-    private String previousAppenedString;
+    private String previousAppendedString;
 
     private boolean mPageFinishedLoading;
     private LifeState mLifeState = LifeState.Init;
@@ -1475,7 +1475,7 @@ public class ContentView extends FrameLayout {
                     if (toCompare.equals(urlText)) {
                         mSetTheRealUrlString = false;
                         previousMetUrl = metUrl.getText().toString();
-                        previousAppenedString = stringToAppend;
+                        previousAppendedString = stringToAppend;
                         metUrl.setText(urlText + stringToAppend);
                         mSetTheRealUrlString = true;
                         metUrl.setSelection(urlText.length(), urlText.length() + stringToAppend.length());
@@ -1497,14 +1497,14 @@ public class ContentView extends FrameLayout {
         @Override
         public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
             String urlText = metUrl.getText().toString();
-            if(previousMetUrl != null && previousAppenedString != null) {
+            if(previousMetUrl != null && previousAppendedString != null) {
                 // Small hack to get around the autocomplete bug in Android 5.0.2
-                String previousUrlText = previousMetUrl + previousAppenedString;
+                String previousUrlText = previousMetUrl + previousAppendedString;
                 int difference = urlText.length() - previousUrlText.length();
                 if(difference == 1) {
                     String urtlTextStart = urlText.substring(0, previousMetUrl.length());
                     String urtlTextEnd = urlText.substring(previousMetUrl.length() + 1, urlText.length());
-                    if(urtlTextStart.equals(previousMetUrl) && urtlTextEnd.equals(previousAppenedString)) {
+                    if(urtlTextStart.equals(previousMetUrl) && urtlTextEnd.equals(previousAppendedString)) {
                         String textToSet = urlText.substring(0, previousMetUrl.length() + 1);
                         metUrl.setText(textToSet);
                         metUrl.setSelection(textToSet.length());

--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
@@ -133,8 +133,8 @@ public class ContentView extends FrameLayout {
     private AutoCompleteTextView metUrl;
     private ImageButton mbtUrlClear;
     private FrameLayout mContentEditUrl;
-    private String previousMetUrl;
-    private String previousAppendedString;
+    private String mPreviousMetUrl;
+    private String mPreviousAppendedString;
 
     private boolean mPageFinishedLoading;
     private LifeState mLifeState = LifeState.Init;
@@ -1474,8 +1474,8 @@ public class ContentView extends FrameLayout {
                     String toCompare = suggestedString.substring(0, urlText.length());
                     if (toCompare.equals(urlText)) {
                         mSetTheRealUrlString = false;
-                        previousMetUrl = metUrl.getText().toString();
-                        previousAppendedString = stringToAppend;
+                        mPreviousMetUrl = metUrl.getText().toString();
+                        mPreviousAppendedString = stringToAppend;
                         metUrl.setText(urlText + stringToAppend);
                         mSetTheRealUrlString = true;
                         metUrl.setSelection(urlText.length(), urlText.length() + stringToAppend.length());
@@ -1497,15 +1497,15 @@ public class ContentView extends FrameLayout {
         @Override
         public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
             String urlText = metUrl.getText().toString();
-            if(previousMetUrl != null && previousAppendedString != null) {
-                // Small hack to get around the autocomplete bug in Android 5.0.2
-                String previousUrlText = previousMetUrl + previousAppendedString;
+            if(mPreviousMetUrl != null && mPreviousAppendedString != null) {
+                // Small hack to get around the autocomplete bug when using ZenUI keyboard
+                String previousUrlText = mPreviousMetUrl + mPreviousAppendedString;
                 int difference = urlText.length() - previousUrlText.length();
                 if(difference == 1) {
-                    String urtlTextStart = urlText.substring(0, previousMetUrl.length());
-                    String urtlTextEnd = urlText.substring(previousMetUrl.length() + 1, urlText.length());
-                    if(urtlTextStart.equals(previousMetUrl) && urtlTextEnd.equals(previousAppendedString)) {
-                        String textToSet = urlText.substring(0, previousMetUrl.length() + 1);
+                    String urtlTextStart = urlText.substring(0, mPreviousMetUrl.length());
+                    String urtlTextEnd = urlText.substring(mPreviousMetUrl.length() + 1, urlText.length());
+                    if(urtlTextStart.equals(mPreviousMetUrl) && urtlTextEnd.equals(mPreviousAppendedString)) {
+                        String textToSet = urlText.substring(0, mPreviousMetUrl.length() + 1);
                         metUrl.setText(textToSet);
                         metUrl.setSelection(textToSet.length());
                     }

--- a/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
+++ b/Application/LinkBubble/src/main/java/com/linkbubble/ui/ContentView.java
@@ -133,6 +133,8 @@ public class ContentView extends FrameLayout {
     private AutoCompleteTextView metUrl;
     private ImageButton mbtUrlClear;
     private FrameLayout mContentEditUrl;
+    private String previousMetUrl;
+    private String previousAppenedString;
 
     private boolean mPageFinishedLoading;
     private LifeState mLifeState = LifeState.Init;
@@ -1472,6 +1474,8 @@ public class ContentView extends FrameLayout {
                     String toCompare = suggestedString.substring(0, urlText.length());
                     if (toCompare.equals(urlText)) {
                         mSetTheRealUrlString = false;
+                        previousMetUrl = metUrl.getText().toString();
+                        previousAppenedString = stringToAppend;
                         metUrl.setText(urlText + stringToAppend);
                         mSetTheRealUrlString = true;
                         metUrl.setSelection(urlText.length(), urlText.length() + stringToAppend.length());
@@ -1493,6 +1497,20 @@ public class ContentView extends FrameLayout {
         @Override
         public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
             String urlText = metUrl.getText().toString();
+            if(previousMetUrl != null && previousAppenedString != null) {
+                // Small hack to get around the autocomplete bug in Android 5.0.2
+                String previousUrlText = previousMetUrl + previousAppenedString;
+                int difference = urlText.length() - previousUrlText.length();
+                if(difference == 1) {
+                    String urtlTextStart = urlText.substring(0, previousMetUrl.length());
+                    String urtlTextEnd = urlText.substring(previousMetUrl.length() + 1, urlText.length());
+                    if(urtlTextStart.equals(previousMetUrl) && urtlTextEnd.equals(previousAppenedString)) {
+                        String textToSet = urlText.substring(0, previousMetUrl.length() + 1);
+                        metUrl.setText(textToSet);
+                        metUrl.setSelection(textToSet.length());
+                    }
+                }
+            }
             if (!mFirstTimeUrlTyped &&
                     (urlText.equals(mAdapter.mRealUrlBarConstraint) || mAdapter.mRealUrlBarConstraint.length() > urlText.length())) {
                 mApplyAutoSuggestion = false;


### PR DESCRIPTION
In android 5.0.2, the URL autocompletion wasn't working properly, every
text appened to the URL was unselected before the user enters a new
character.
"a" was autocompleted to "abcnews.com", the cursor being between "a" and
"b", if the user then typed "b", the resulting URL was "abbcnews.com".